### PR TITLE
질문 삭제 기능 추가 및 API 요청 핸들러 수정

### DIFF
--- a/src/components/global/utils/apiUtil.js
+++ b/src/components/global/utils/apiUtil.js
@@ -109,7 +109,11 @@ export const fetchAPI = async (endpoint, method, body) => {
   const responseData = await response.json();
 
   if (!response.ok) {
-    throw new Error('요청 처리 실패', response.message);
+    return {
+      error: true,
+      status: response.status,
+      message: responseData.message || '알 수 없는 오류'
+    };     
   }
 
   return responseData;

--- a/src/components/pages/postPage/questionDetailPage.tsx
+++ b/src/components/pages/postPage/questionDetailPage.tsx
@@ -159,9 +159,16 @@ function QuestionDetailPage() {
       // 답변 내용이 비어있을 경우 에러 던지기
       if (answerRef.current?.value === '') {
         throw new Error('크기가 1에서 500 사이여야 합니다');
+
       }
 
       const answerResponse = await fetchAPI('/api/answer', 'POST', requestData);
+
+      if (!answerResponse.ok){
+        if (answerResponse.status === 400) {
+          showErrorToast('질문 작성자는 답변 작성이 불가능합니다.')
+        } 
+      }
       if (answerResponse.statusCode === 'CREATED' && answerRef.current) {
         setPostAnswer(answerRef.current?.value);
         showSuccessToast('답변이 등록되었습니다.');
@@ -246,22 +253,22 @@ function QuestionDetailPage() {
   const handleClickDelete = async () => {
     try {
         const response = await fetchAPI(`/api/question/${questionId}`, 'DELETE');
-
-        if (!response.ok) {
+       
+        if (response.error) {
           console.log(response)
             if (response.status === 409) {
-                showErrorToast('이미 처리된 요청입니다. 새로고침 후 다시 시도해주세요.');
+                showErrorToast('답변이 달린 게시물은 삭제할 수 없습니다. ');
                 return;
             }
             throw new Error('요청 처리 중 오류가 발생했습니다.');
-        }
+        } else if (confirm('삭제하시겠습니까?')) {
+          showSuccessToast('질문이 삭제되었습니다.');
+          const pathSegments = window.location.pathname.split('/');
+          const companyId = pathSegments[2];
+          navigate(`/company-info/${companyId}`);
+      }
 
-        if (confirm('삭제하시겠습니까?')) {
-            showSuccessToast('질문이 삭제되었습니다.');
-            const pathSegments = window.location.pathname.split('/');
-            const companyId = pathSegments[2];
-            navigate(`/company-info/${companyId}`);
-        }
+       
     } catch (error) {
       if (error instanceof Error) 
       

--- a/src/components/pages/postPage/questionDetailPage.tsx
+++ b/src/components/pages/postPage/questionDetailPage.tsx
@@ -223,32 +223,33 @@ function QuestionDetailPage() {
       if (error instanceof Error) showErrorToast(error.message);
     }
   };
-
   const handleClickDelete = async () => {
-  
-    const deleteBody = {
-      title: questionTitle,
-      content: questionContent,
-      questionStatus: false,
-    };
-    console.log(questionId);
     try {
-        fetchAPI(`/api/question/${questionId}`, 'DELETE', deleteBody);
-       if (confirm('삭제하시겠습니까?')){
-        showSuccessToast('질문이 삭제되었습니다.');
-        const pathSegments = window.location.pathname.split('/');
-        const companyId = pathSegments[2];
+        const response = await fetchAPI(`/api/question/${questionId}`, 'DELETE');
 
-        navigate(`/company-info/${companyId}`);
-      
-      }
+        if (!response.ok) {
+          console.log(response)
+            if (response.status === 409) {
+                showErrorToast('이미 처리된 요청입니다. 새로고침 후 다시 시도해주세요.');
+                return;
+            }
+            throw new Error('요청 처리 중 오류가 발생했습니다.');
+        }
+
+        if (confirm('삭제하시겠습니까?')) {
+            showSuccessToast('질문이 삭제되었습니다.');
+            const pathSegments = window.location.pathname.split('/');
+            const companyId = pathSegments[2];
+            navigate(`/company-info/${companyId}`);
+        }
     } catch (error) {
-      if (error instanceof Error) 
-      
-      showErrorToast(error.message);
-      console.log(error)
+        if (error instanceof Error) {
+            showErrorToast(error.message);
+            console.log(error);
+        }
     }
-  };
+};
+
 
   const handleReportSubmit = async () => {
     toggleReportPopup();

--- a/src/components/ui/question/answer.tsx
+++ b/src/components/ui/question/answer.tsx
@@ -154,8 +154,14 @@ function AnswerModule({
 
   const handleClickDelete = async () => {
     try {
-      if (confirm('삭제하시겠습니까?'))
-        showSuccessToast('답변이 삭제되었습니다.');
+      if (confirm('삭제하시겠습니까?')){
+        const response = await fetchAPI(`/api/question/${answerId}`, 'DELETE');
+        if (response.error) {
+          showErrorToast('답변 삭제가 불가능합니다.')
+        }else{
+          showSuccessToast('답변이 삭제되었습니다.');}
+
+        }
     } catch (error) {
       if (error instanceof Error) showErrorToast(error.message);
     }


### PR DESCRIPTION
# ✨(#이슈 번호)
#285 

# ✏️내용
- 질문 삭제 기능 추가
- 질문 삭제 시, 답변 있을 경우 에러 처리
- API 핸들러 에러 코드 리턴하도록 수정

# 📸스크린샷

# 🎁참고사항
- 답변 삭제 API가 분리되었을까요? 기존에는 질문 삭제에 통합으로 있던 것으로 기억하는데, 확인 부탁드립니다!(현재는 답변 삭제 시 에러 토스트만 발생)
- 질문 수정도 답변이 있을 떄는 409 에러가 발생하는 것 같습니다. 애초에 수정 페이지로 못가도록, 에러 처리가 필요해 보입니다.